### PR TITLE
Necessary additions

### DIFF
--- a/data/prefixes.js
+++ b/data/prefixes.js
@@ -780,10 +780,10 @@ f(over, { match: /a #1/ }, browsers =>
     })
 );
 
-// CSS color-adjust property
-f(require('caniuse-lite/data/features/css-color-adjust.json'), browsers =>
+// CSS color-adjust
+f(require('caniuse-lite/data/features/css-color-adjust.js'), browsers =>
     prefix(['color-adjust'], {
-        feature: 'color-adjust',
+        feature: 'css-color-adjust',
         browsers
     })
 );

--- a/lib/hacks/color-adjust.js
+++ b/lib/hacks/color-adjust.js
@@ -1,9 +1,8 @@
-
 const Declaration = require('../declaration');
 
 class ColorAdjust extends Declaration {
 
-    static names = ['color-adjust'];
+    static names = ['color-adjust', 'print-color-adjust'];
 
     /**
      * Change property name for WebKit-based browsers

--- a/test/cases/color-adjust.css
+++ b/test/cases/color-adjust.css
@@ -1,7 +1,7 @@
-a {
+.a {
     color-adjust: economy;
 }
 
-b {
+.b {
     color-adjust: exact;
 }

--- a/test/cases/color-adjust.out.css
+++ b/test/cases/color-adjust.out.css
@@ -1,9 +1,9 @@
-a {
+.a {
     -webkit-print-color-adjust: economy;
-    color-adjust: economy;
+            color-adjust: economy;
 }
 
-b {
+.b {
     -webkit-print-color-adjust: exact;
-    color-adjust: exact;
+            color-adjust: exact;
 }


### PR DESCRIPTION
Hello again, @soul-wish :)

Some changes:
- I created a stub for `node_modules/caniuse-lite/data/features/css-color-adjust.js` in order to let us run tests **before** our PR to caniuse will be accepted.
- It seems that CSS output is indented by prefix-endings, so without correct indentation tests are red.
- `static names` should contain all names without prefixes to let autoprefixer work, same here, without it tests fail. 
- All CSS features in caniuse starts with 'css' prefix and points to .js files, not .json.

To run the tests, add stub into the appropriate folder, run these commands:
- `yarn install`
- `yarn global add jest`
- `yarn test`

[Link to css-color-adjust.js stub](https://gist.github.com/yuriyalekseyev/0d1f80cd10fb867ee9ddda6af88975c7)